### PR TITLE
Fix non-numeric error code issue

### DIFF
--- a/php/fotolia-api.php
+++ b/php/fotolia-api.php
@@ -839,7 +839,7 @@ class Fotolia_Api
                 $error_msg = $res['error'];
 
                 if (!empty($res['code'])) {
-                    $error_code = $res['code'];
+                    $error_code = (int) $res['code'];
                 }
             } else {
                 $error_msg = 'Invalid response HTTP code: ' . $http_code;


### PR DESCRIPTION
Hi Olivier,

This tweak deals with errors we're getting on our live service from a rare issue with getSearchResults - I'm guessing the error code returned is non-numeric, and hence raises a "Wrong parameters for Exception([string $exception [, long $code ]])" error at line 848.

Best,

Jon
