### PR TITLE
Add getSeasonalGalleries method to PHP kit

### DIFF
--- a/php/fotolia-api.php
+++ b/php/fotolia-api.php
@@ -202,6 +202,23 @@ class Fotolia_Api
     }
 
     /**
+     * This method returns public seasonal galleries for a defined language
+     *
+     * @param  int    $language_id
+     * @return array
+     */
+    public function getSeasonalGalleries($language_id = Fotolia_Api::LANGUAGE_ID_EN_US, $thumbnail_size = 110, $theme_id = 0)
+    {
+        $args = array(
+             'language_id' => $language_id
+             ,'thumbnail_size' => $thumbnail_size
+        );
+        if ((int)$theme_id > 0) $args['theme_id'] = $theme_id;
+
+        return $this->_api('getSeasonalGalleries', $args);
+    }
+
+    /**
      * This method returns Fotolia list of countries.
      *
      * @param  int    $language_id
@@ -944,6 +961,7 @@ class Fotolia_Api
             case 'getCategories2':
             case 'getTags':
             case 'getGalleries':
+            case 'getSeasonalGalleries':
             case 'getCountries':
                 return 'search';
 


### PR DESCRIPTION
There is a problem with arg theme_id : cannot to be set to 0 (zero) for
get all galleries. So script will added it to args if the $theme_id is
more than 0
