### PR TITLE
Remove duplicate constructor

### DIFF
--- a/java/org/webservice/fotolia/FotoliaApi.java
+++ b/java/org/webservice/fotolia/FotoliaApi.java
@@ -86,17 +86,6 @@ public class FotoliaApi
     public FotoliaApi(final String api_key)
     {
         this._api_key = api_key;
-        this.setHttpsMode(false);
-    }
-
-    /**
-     * Constructor
-     *
-     * @param  api_key
-     */
-    public FotoliaApi(final String api_key)
-    {
-        this._api_key = api_key;
     }
 
     /**


### PR DESCRIPTION
The Java API could not be built due to a duplicate constructor. The removal of the optional HTTPS support via a constructor parameter clashed with another constructor.